### PR TITLE
chore: improved OpenSSF score

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,14 +9,16 @@ on:
     - cron: "0 6 * * 1"
 
 permissions:
-  actions: read
   contents: read
-  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,14 +4,15 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -26,12 +27,17 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
+
+      - uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
 
       - name: Build cross-platform binaries
         env:
@@ -60,8 +66,14 @@ jobs:
       - name: Generate checksums
         run: sha256sum gozork-*.tar.gz > checksums-sha256.txt
 
+      - name: Sign artifacts
+        run: |
+          for f in gozork-*.tar.gz checksums-sha256.txt; do
+            cosign sign-blob --yes "$f" --bundle "${f}.sigstore"
+          done
+
       - name: Upload release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
-        run: gh release upload "$TAG" gozork-*.tar.gz checksums-sha256.txt --clobber
+        run: gh release upload "$TAG" gozork-*.tar.gz checksums-sha256.txt *.sigstore --clobber


### PR DESCRIPTION
## Description

Improves OpenSSF Scorecard score for two checks: **Token-Permissions** and **Signed-Releases**.

**Token-Permissions** — move write permissions from workflow level to job level (principle of least privilege):
- `release.yml`: top-level set to `permissions: {}`, write perms scoped to each job
- `codeql.yml`: `security-events: write` moved from top-level to `analyze` job

**Signed-Releases** — sign release artifacts using cosign keyless signing (sigstore):
- Install `cosign` via `sigstore/cosign-installer@v3.9.2`
- Sign each tarball and the checksums file, producing `.sigstore` bundles
- Upload `.sigstore` bundles alongside release artifacts

## Type of Change

- [x] CI/Build

## Checklist

- [x] Tests pass (`make test`)
- [x] Linter clean (`make lint`)
- [x] `go vet` clean (`make vet`)